### PR TITLE
Fix: AKS service_cidr overlap and Redis non_ssl_port warning

### DIFF
--- a/infra/tf-app/modules/acr/main.tf
+++ b/infra/tf-app/modules/acr/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_redis_cache" "redis_test" {
 
   sku_name = "Basic"
 
-  enable_non_ssl_port = true
+  non_ssl_port_enabled = true
 
 }
 
@@ -44,7 +44,9 @@ resource "azurerm_redis_cache" "redis_prod" {
 
   sku_name = "Basic"
 
-  enable_non_ssl_port = true
+  non_ssl_port_enabled = true
+
+
 
 }
 

--- a/infra/tf-app/modules/aks/main.tf
+++ b/infra/tf-app/modules/aks/main.tf
@@ -25,6 +25,8 @@ resource "azurerm_kubernetes_cluster" "test" {
   network_profile {
     network_plugin = "azure"
     network_policy = "azure"
+    service_cidr   = "10.240.0.0/16"
+    dns_service_ip = "10.240.0.10"
   }
 
   api_server_access_profile {
@@ -64,6 +66,8 @@ resource "azurerm_kubernetes_cluster" "prod" {
   network_profile {
     network_plugin = "azure"
     network_policy = "azure"
+    service_cidr   = "10.241.0.0/16"
+    dns_service_ip = "10.241.0.10"
   }
 
   api_server_access_profile {


### PR DESCRIPTION
Fix: AKS service_cidr overlap and Redis non_ssl_port warning