### PR TITLE
Connect AKS clusters to ACR for image pulling

### DIFF
--- a/infra/tf-app/main.tf
+++ b/infra/tf-app/main.tf
@@ -14,10 +14,12 @@ module "aks" {
 }
 
 module "acr" {
-  source              = "./modules/acr"
-  location            = var.location
-  resource_group_name = module.network.resource_group_name
-  acr_name            = "fp11weatheracr"
-  redis_test_name     = "fp11redistest"
-  redis_prod_name     = "fp11redisprod"
+  source                  = "./modules/acr"
+  location                = var.location
+  resource_group_name     = module.network.resource_group_name
+  acr_name                = "fp11weatheracr"
+  redis_test_name         = "fp11redistest"
+  redis_prod_name         = "fp11redisprod"
+  test_aks_identity_id    = module.aks.test_aks_identity_id
+  prod_aks_identity_id    = module.aks.prod_aks_identity_id
 }

--- a/infra/tf-app/main.tf
+++ b/infra/tf-app/main.tf
@@ -14,12 +14,12 @@ module "aks" {
 }
 
 module "acr" {
-  source                  = "./modules/acr"
-  location                = var.location
-  resource_group_name     = module.network.resource_group_name
-  acr_name                = "fp11weatheracr"
-  redis_test_name         = "fp11redistest"
-  redis_prod_name         = "fp11redisprod"
-  test_aks_identity_id    = module.aks.test_aks_identity_id
-  prod_aks_identity_id    = module.aks.prod_aks_identity_id
+  source               = "./modules/acr"
+  location             = var.location
+  resource_group_name  = module.network.resource_group_name
+  acr_name             = "fp11weatheracr"
+  redis_test_name      = "fp11redistest"
+  redis_prod_name      = "fp11redisprod"
+  test_aks_identity_id = module.aks.test_aks_identity_id
+  prod_aks_identity_id = module.aks.prod_aks_identity_id
 }

--- a/infra/tf-app/modules/acr/main.tf
+++ b/infra/tf-app/modules/acr/main.tf
@@ -51,3 +51,16 @@ resource "azurerm_redis_cache" "redis_prod" {
 }
 
  
+ # Grant ACR Pull access to AKS Test cluster
+resource "azurerm_role_assignment" "aks_test_acr_pull" {
+  principal_id         = var.test_aks_identity_id
+  role_definition_name = "AcrPull"
+  scope                = azurerm_container_registry.weather_app_acr.id
+}
+
+# Grant ACR Pull access to AKS Prod cluster
+resource "azurerm_role_assignment" "aks_prod_acr_pull" {
+  principal_id         = var.prod_aks_identity_id
+  role_definition_name = "AcrPull"
+  scope                = azurerm_container_registry.weather_app_acr.id
+}

--- a/infra/tf-app/modules/acr/main.tf
+++ b/infra/tf-app/modules/acr/main.tf
@@ -50,8 +50,8 @@ resource "azurerm_redis_cache" "redis_prod" {
 
 }
 
- 
- # Grant ACR Pull access to AKS Test cluster
+
+# Grant ACR Pull access to AKS Test cluster
 resource "azurerm_role_assignment" "aks_test_acr_pull" {
   principal_id         = var.test_aks_identity_id
   role_definition_name = "AcrPull"

--- a/infra/tf-app/modules/acr/variables.tf
+++ b/infra/tf-app/modules/acr/variables.tf
@@ -3,3 +3,5 @@ variable "resource_group_name" {}
 variable "acr_name" {}
 variable "redis_test_name" {}
 variable "redis_prod_name" {}
+variable "test_aks_identity_id" {}
+variable "prod_aks_identity_id" {}

--- a/infra/tf-app/modules/aks/outputs.tf
+++ b/infra/tf-app/modules/aks/outputs.tf
@@ -7,3 +7,11 @@ output "prod_kube_config" {
   value     = azurerm_kubernetes_cluster.prod.kube_config_raw
   sensitive = true
 }
+
+output "test_aks_identity_id" {
+  value = azurerm_kubernetes_cluster.test.identity[0].principal_id
+}
+
+output "prod_aks_identity_id" {
+  value = azurerm_kubernetes_cluster.prod.identity[0].principal_id
+}


### PR DESCRIPTION
This update connects our AKS clusters (test and prod) with the Azure Container Registry (ACR) to allow image pulls for the Remix Weather App.