### PR TITLE
Add ACR Pull Role Assignments for AKS with lifecycle to handle roles

### DIFF
--- a/infra/tf-app/modules/acr/main.tf
+++ b/infra/tf-app/modules/acr/main.tf
@@ -1,61 +1,44 @@
 resource "azurerm_container_registry" "weather_app_acr" {
-
-  name = var.acr_name
-
+  name                = var.acr_name
   resource_group_name = var.resource_group_name
-
-  location = var.location
-
-  sku = "Basic"
-
-  admin_enabled = true
-
+  location            = var.location
+  sku                 = "Basic"
+  admin_enabled       = true
 }
 
 resource "azurerm_redis_cache" "redis_test" {
-
-  name = var.redis_test_name
-
-  location = var.location
-
-  resource_group_name = var.resource_group_name
-
-  capacity = 1
-
-  family = "C"
-
-  sku_name = "Basic"
-
+  name                 = var.redis_test_name
+  location             = var.location
+  resource_group_name  = var.resource_group_name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
   non_ssl_port_enabled = true
-
 }
 
 resource "azurerm_redis_cache" "redis_prod" {
-
-  name = var.redis_prod_name
-
-  location = var.location
-
-  resource_group_name = var.resource_group_name
-
-  capacity = 1
-
-  family = "C"
-
-  sku_name = "Basic"
-
+  name                 = var.redis_prod_name
+  location             = var.location
+  resource_group_name  = var.resource_group_name
+  capacity             = 1
+  family               = "C"
+  sku_name             = "Basic"
   non_ssl_port_enabled = true
-
-
-
 }
-
 
 # Grant ACR Pull access to AKS Test cluster
 resource "azurerm_role_assignment" "aks_test_acr_pull" {
   principal_id         = var.test_aks_identity_id
   role_definition_name = "AcrPull"
   scope                = azurerm_container_registry.weather_app_acr.id
+
+  lifecycle {
+    ignore_changes = [
+      principal_id,
+      role_definition_name,
+      scope
+    ]
+  }
 }
 
 # Grant ACR Pull access to AKS Prod cluster
@@ -63,4 +46,12 @@ resource "azurerm_role_assignment" "aks_prod_acr_pull" {
   principal_id         = var.prod_aks_identity_id
   role_definition_name = "AcrPull"
   scope                = azurerm_container_registry.weather_app_acr.id
+
+  lifecycle {
+    ignore_changes = [
+      principal_id,
+      role_definition_name,
+      scope
+    ]
+  }
 }

--- a/infra/tf-app/outputs.tf
+++ b/infra/tf-app/outputs.tf
@@ -1,0 +1,7 @@
+output "test_aks_identity_id" {
+  value = module.aks.test_aks_identity_id
+}
+
+output "prod_aks_identity_id" {
+  value = module.aks.prod_aks_identity_id
+}


### PR DESCRIPTION
Grant ACR Pull permissions to AKS test and prod clusters using role assignments. 
Added lifecycle block to prevent Terraform errors when role assignments already exist.
